### PR TITLE
Update BasePolicy.php

### DIFF
--- a/src/Policies/BasePolicy.php
+++ b/src/Policies/BasePolicy.php
@@ -55,3 +55,5 @@ class BasePolicy
         return $user->hasPermission($action.'_'.(isset($dataType->name)?$dataType->name:uniqid("name-needed"));
     }
 }
+                                    
+                                    


### PR DESCRIPTION
fix this error: 
Trying to get property 'name' of non-object {"userId":1,"exception":"[object] (ErrorException(code: 0): Trying to get property 'name' of non-object at /var/www/vendor/tcg/voyager/src/Policies/BasePolicy.php:55